### PR TITLE
Added new regexp rules

### DIFF
--- a/oocDef.js
+++ b/oocDef.js
@@ -33,6 +33,7 @@ define(["require", "exports"], function (require, exports) {
         // The main tokenizer for our languages
         tokenizer: {
             root: [
+                [/[\_a-zA-Z]+\:/, 'identifier'],
                 [/[A-Z]+\w*/, 'type.$0'],
                 [/[a-zA-Z_]\w*/, { cases: { '@keywords': { token: 'keyword.$0' }, '@default': 'identifier' } }],
                 { include: '@whitespace' },
@@ -50,7 +51,7 @@ define(["require", "exports"], function (require, exports) {
                 [/"/, { token: 'string.quote', bracket: '@open', next: '@string' }],
                 [/'[^\\']'/, 'string'],
                 [/(')(@escapes)(')/, ['string', 'string.escape', 'string']],
-                [/'/, 'string.invalid']
+                [/'/, 'string.invalid'],
             ],
             whitespace: [
                 [/[ \t\r\n]+/, ''],

--- a/oocDef.js
+++ b/oocDef.js
@@ -34,7 +34,7 @@ define(["require", "exports"], function (require, exports) {
         tokenizer: {
             root: [
                 [/[\_a-zA-Z]+\:/, 'identifier'],
-                [/[A-Z]+\w*/, 'type.$0'],
+                [/[\_A-Z]+\w*/, 'type.$0'],
                 [/[a-zA-Z_]\w*/, { cases: { '@keywords': { token: 'keyword.$0' }, '@default': 'identifier' } }],
                 { include: '@whitespace' },
                 [/^\s*#\w+/, 'keyword'],


### PR DESCRIPTION
- Identifiers that are keywords are no longer highlighted as keywords
- Fixed so type identifiers prefixed with an underscore are properly highlighted

Examples:
`use: func { /* */ } // use is not highlighted as a keyword`
`_privateVariable: _PrivateType // _PrivateType is properly highlighted`
